### PR TITLE
Change all controllers to use a ramp up and down velocity profile.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,6 +86,7 @@
     },
     "cmake.configureOnOpen": false,
     "cSpell.words": [
+        "decel",
         "hinf"
     ]
 }

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -17,6 +17,7 @@ from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 from visualization_msgs.msg import Marker
 import numpy as np
+import sys
 
 
 class Controller(Node):
@@ -308,11 +309,10 @@ def main(args=None):
     except SystemExit:
         pass
     except ExternalShutdownException:
-        pass
-
-    # Destroy the node explicitly
-    car_controller.destroy_node()
-    rclpy.shutdown()
+        sys.exit(1)
+    finally:
+        car_controller.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -258,7 +258,7 @@ class Controller(Node):
         self.cmd_steer = np.clip(self.cmd_steer, -max_steer, max_steer)
         if self.cmd_steer != max_steer:
             self.get_logger().warning(
-                f"Steering saturated. Requested {max_steer}, but got {self.cmd_steer}"
+                f"Steering saturated. Requested < |{max_steer}|, but got {self.cmd_steer}"
             )
 
         # Raise heartbeat_alarm if heartbeat hasn't been received.

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -269,25 +269,26 @@ class Controller(Node):
         ):
             self.heartbeat_alarm = 1
             self.get_logger().info("HEARTBEAT ALARM ACTIVE")
-            pass
+            self.cmd_steer = 0.0
+            self.cmd_speed = 0.0
 
         # last_waypoint_dist = np.linalg.norm(
         #     [self.waypoints.x[-1] - self.x, self.waypoints.y[-1] - self.y]
         # )
 
-        if (
-            self.v > self.v_max
-            or self.heartbeat_alarm == 1
-            or self.run_flag == 0
-            # or last_waypoint_dist < self.final_thresh
-        ):
-            # Overwrite commands to steer straight and stop.
+        # Handle each error separately for clear info message.
+        if self.v > self.v_max:
             self.cmd_steer = 0.0
             self.cmd_speed = 0.0
-            self.get_logger().info(
-                "Speed unsafe, heartbeat failed, run flag disabled, or close to "
-                "end of line."
-            )
+            self.get_logger().info("Speed unsafe")
+        if self.run_flag == 0:
+            self.cmd_steer = 0.0
+            self.cmd_speed = 0.0
+            self.get_logger().info("Run flag disabled")
+        # if last_waypoint_dist < self.final_thresh:
+        #     self.cmd_steer = 0.0
+        #     self.cmd_speed = 0.0
+        #     self.get_logger().info("Close to end of line.")
 
         # Publish controller command.
         ackermann_command = AckermannDriveStamped()

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -208,7 +208,7 @@ class Controller(Node):
         pose_stamped.header.frame_id = "map"
         pose_stamped.header.stamp = self.get_clock().now().to_msg()
         pose_stamped.pose = pose
-        self.pose_publisher.publish(self.pose_markers)
+        self.pose_publisher.publish(pose_stamped)
 
     def controller(self):
         """Publish current_pose, ref_point marker, and control command."""

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -1,6 +1,7 @@
 import rclpy
-from rclpy.node import Node, QoSProfile
+from rclpy.executors import ExternalShutdownException
 from rclpy.duration import Duration
+from rclpy.node import Node, QoSProfile
 from nav_msgs.msg import Odometry
 from tf_transformations import euler_from_quaternion
 from ackermann_msgs.msg import AckermannDriveStamped
@@ -300,7 +301,14 @@ def main(args=None):
 
     car_controller = Controller()
 
-    rclpy.spin(car_controller)
+    try:
+        rclpy.spin(car_controller)
+    except KeyboardInterrupt:
+        pass
+    except SystemExit:
+        pass
+    except ExternalShutdownException:
+        pass
 
     # Destroy the node explicitly
     car_controller.destroy_node()

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -256,7 +256,7 @@ class Controller(Node):
         # Clip steer angle to max steer.
         max_steer = self.get_parameter("max_steer").value
         self.cmd_steer = np.clip(self.cmd_steer, -max_steer, max_steer)
-        if self.cmd_steer != max_steer:
+        if abs(self.cmd_steer) >= max_steer:
             self.get_logger().warning(
                 f"Steering saturated. Requested < |{max_steer}|, but got {self.cmd_steer}"
             )

--- a/src/ros2_car_control/ros2_car_control/controller.py
+++ b/src/ros2_car_control/ros2_car_control/controller.py
@@ -62,6 +62,7 @@ class Controller(Node):
         self.declare_parameter("heartbeat_timeout", 1.0)
         self.declare_parameter("max_steer", 0.65)
         self.declare_parameter("speed_setpoint", 1.0)
+        self.declare_parameter("a_max", 1.0)
 
         # Get generic parameter values.
         self.control_method = self.get_parameter("control_method").value
@@ -70,6 +71,7 @@ class Controller(Node):
         control_params = {
             "max_steer": self.get_parameter("max_steer").value,
             "speed_setpoint": self.get_parameter("speed_setpoint").value,
+            "max_accel": self.get_parameter("a_max").value,
         }
 
         # Define safety-check flags.

--- a/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
+++ b/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
@@ -4,39 +4,69 @@ import yaml
 from PIL import Image
 import os
 
-class waypoints():
-     def __init__(self):
-        username = os.getlogin()
-        waypointsdir = str('/home/'+username+'/FML_AutonomousCar/src/ros2_car_control/config/waypoints.json')
-        mapdir = str('/home/'+username+'/FML_AutonomousCar/src/car_slam/config/lab_map.pgm')
-        mapcfgdir = str('/home/'+username+'/FML_AutonomousCar/src/car_slam/config/lab_map.yaml')
-        #Get Image Properties
-        graph_height = Image.open(mapdir).size[1]
-        #print(graph_height)
 
-        with open(mapcfgdir,"r") as read_file:
+class waypoints:
+    def __init__(self):
+        username = os.getlogin()
+        waypointsdir = str(
+            "/home/"
+            + username
+            + "/FML_AutonomousCar/src/ros2_car_control/config/waypoints.json"
+        )
+        mapdir = str(
+            "/home/" + username + "/FML_AutonomousCar/src/car_slam/config/lab_map.pgm"
+        )
+        mapcfgdir = str(
+            "/home/" + username + "/FML_AutonomousCar/src/car_slam/config/lab_map.yaml"
+        )
+        # Get Image Properties
+        graph_height = Image.open(mapdir).size[1]
+        # print(graph_height)
+
+        with open(mapcfgdir, "r") as read_file:
             yaml_params = yaml.load(read_file, Loader=yaml.SafeLoader)
             resolution = yaml_params["resolution"]
             origin = yaml_params["origin"]
-            #print(resolution)
-            #print(origin)
+            # print(resolution)
+            # print(origin)
 
-        with open(waypointsdir,"r") as read_file:
+        with open(waypointsdir, "r") as read_file:
             waypointsfile = json.load(read_file)
-            untranslated_waypoints = waypointsfile['smoothed_wpts']
-            self.x = np.array([x[0] for x in untranslated_waypoints])
-            self.y = np.array([y[1] for y in untranslated_waypoints])
-        
-            self.x = self.x - origin[0] + 1.3   #comment if not using conversions from starter map
-            self.y = -self.y + origin[1] - 1.4 + 2*(graph_height*resolution)
-            #print(self.y)
+            untranslated_waypoints = waypointsfile["smoothed_wpts"]
+            translate_x = lambda x: x - origin[0] + 1.3
+            translate_y = (
+                lambda y: -y + origin[1] - 1.4 + 2 * (graph_height * resolution)
+            )
+            self.x = [translate_x(untranslated_waypoints[0][0])]
+            self.y = [translate_y(untranslated_waypoints[0][1])]
+            self.d = [0]
+            for i in range(1, len(untranslated_waypoints)):
+                prev_point = np.array(
+                    translate_x(untranslated_waypoints[i - 1][0]),
+                    translate_y(untranslated_waypoints[i - 1][1]),
+                )
+                point = np.array(
+                    translate_x(untranslated_waypoints[i][0]),
+                    translate_y(untranslated_waypoints[i][1]),
+                )
+                self.x.append(point[0])
+                self.y.append(point[1])
+                distance = np.linalg.norm(point - prev_point)
+                self.d.append(self.d[i - 1] + distance)
+
+            self.x = (
+                self.x - origin[0] + 1.3
+            )  # comment if not using conversions from starter map
+            self.y = -self.y + origin[1] - 1.4 + 2 * (graph_height * resolution)
+            # print(self.y)
 
         x_diffs = np.diff(self.x)
         y_diffs = np.diff(self.y)
-        self.psi = np.arctan2(y_diffs,x_diffs)
+        self.psi = np.arctan2(y_diffs, x_diffs)
         self.psi = np.append(self.psi, self.psi[-1])
-        #print(f"First point: [{self.x[1]},{self.y[1]}]")
-        #print(f"Last point: [{self.x[-1]},{self.y[-1]}]")
+        # print(f"First point: [{self.x[1]},{self.y[1]}]")
+        # print(f"Last point: [{self.x[-1]},{self.y[-1]}]")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     waypoints()

--- a/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
+++ b/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
@@ -31,34 +31,24 @@ class waypoints:
             # print(origin)
 
         with open(waypointsdir, "r") as read_file:
+            # Get untranslated waypoints.
             waypointsfile = json.load(read_file)
-            untranslated_waypoints = waypointsfile["smoothed_wpts"]
-            translate_x = lambda x: x - origin[0] + 1.3
-            translate_y = (
-                lambda y: -y + origin[1] - 1.4 + 2 * (graph_height * resolution)
-            )
-            self.x = [translate_x(untranslated_waypoints[0][0])]
-            self.y = [translate_y(untranslated_waypoints[0][1])]
-            self.d = [0]
-            for i in range(1, len(untranslated_waypoints)):
-                prev_point = np.array(
-                    translate_x(untranslated_waypoints[i - 1][0]),
-                    translate_y(untranslated_waypoints[i - 1][1]),
-                )
-                point = np.array(
-                    translate_x(untranslated_waypoints[i][0]),
-                    translate_y(untranslated_waypoints[i][1]),
-                )
-                self.x.append(point[0])
-                self.y.append(point[1])
-                distance = np.linalg.norm(point - prev_point)
-                self.d.append(self.d[i - 1] + distance)
+            untranslated_waypoints = waypointsfile['smoothed_wpts']
+            points = np.array([point[0:2] for point in untranslated_waypoints])
 
-            self.x = (
-                self.x - origin[0] + 1.3
-            )  # comment if not using conversions from starter map
-            self.y = -self.y + origin[1] - 1.4 + 2 * (graph_height * resolution)
-            # print(self.y)
+            # Translate waypoints.
+            points[:,0] = points[:,0] - origin[0] + 1.3
+            points[:,1] = -points[:,1] + origin[1] - 1.4 + 2*(graph_height*resolution)
+
+            # Compute distance attribute.
+            self.x = []
+            self.y = []
+            self.d = [0]
+            for i in range(1, len(points)):
+                self.x.append(points[i,0])
+                self.y.append(points[i,1])
+                distance = np.linalg.norm(points[i] - points[i-1])
+                self.d.append(self.d[i - 1] + distance)
 
         x_diffs = np.diff(self.x)
         y_diffs = np.diff(self.y)

--- a/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
+++ b/src/ros2_car_control/ros2_car_control/fetchWaypoints.py
@@ -54,8 +54,12 @@ class waypoints:
         y_diffs = np.diff(self.y)
         self.psi = np.arctan2(y_diffs, x_diffs)
         self.psi = np.append(self.psi, self.psi[-1])
-        # print(f"First point: [{self.x[1]},{self.y[1]}]")
-        # print(f"Last point: [{self.x[-1]},{self.y[-1]}]")
+
+        # Convert to arrays.
+        self.x = np.array(self.x)
+        self.y = np.array(self.y)
+        self.psi = np.array(self.psi)
+        self.d = np.array(self.d)
 
 
 if __name__ == "__main__":

--- a/src/ros2_car_control/ros2_car_control/mpcController.py
+++ b/src/ros2_car_control/ros2_car_control/mpcController.py
@@ -1,6 +1,6 @@
 import numpy as np
 from acados_template import AcadosOcpSolver
-from utilities import get_accel_dist, get_closest_waypoint, get_speed_cmd
+from ros2_car_control.utilities import get_accel_dist, get_closest_waypoint, get_speed_cmd
 
 
 class MPCController:

--- a/src/ros2_car_control/ros2_car_control/mpcController.py
+++ b/src/ros2_car_control/ros2_car_control/mpcController.py
@@ -1,11 +1,18 @@
 import numpy as np
 from acados_template import AcadosOcpSolver
+from utilities import get_accel_dist, get_closest_waypoint, get_speed_cmd
 
-class MPCController():
-    def __init__(self,waypoints,ctrl_params):
+
+class MPCController:
+    def __init__(self, waypoints, ctrl_params):
         self.Tf = ctrl_params.get("tf")  # prediction horizon
         self.N = ctrl_params.get("N")  # number of discretization steps
-        self.v = ctrl_params.get("speed_setpoint") # Velocity Setpoint
+        self.velocity_setpoint = ctrl_params.get("speed_setpoint")  # Velocity Setpoint
+        self.max_accel = ctrl_params.get("max_accel")
+        self.d_accel = get_accel_dist(self.velocity_setpoint, self.max_accel)
+        self.d_decel = self.waypoints.d[-1] - self.d_accel
+
+        self.waypoints = waypoints
         self.xrefs = np.array(waypoints.x)
         self.yrefs = np.array(waypoints.y)
         self.psirefs = np.array(waypoints.psi)
@@ -16,63 +23,104 @@ class MPCController():
         sumDist = 0
         srefs = np.array([])
         for i in range(len(self.xrefs)):
-            srefs = np.append(srefs,sumDist)
+            srefs = np.append(srefs, sumDist)
             try:
-                sumDist = sumDist + np.sqrt((self.xrefs[i+1] - self.xrefs[i])**2 + (self.yrefs[i+1] - self.yrefs[i])**2)
+                sumDist = sumDist + np.sqrt(
+                    (self.xrefs[i + 1] - self.xrefs[i]) ** 2
+                    + (self.yrefs[i + 1] - self.yrefs[i]) ** 2
+                )
             except IndexError:
                 continue
         self.srefs = srefs
 
-        self.acados_solver =  AcadosOcpSolver(None,generate=False,build=False,json_file="acados_ocp.json")
+        self.acados_solver = AcadosOcpSolver(
+            None, generate=False, build=False, json_file="acados_ocp.json"
+        )
 
         # Dimensions
-        self.nx = ctrl_params.get("nx") # model.x.size()[0]
-        self.nu = ctrl_params.get("nu") # model.u.size()[0]
+        self.nx = ctrl_params.get("nx")  # model.x.size()[0]
+        self.nu = ctrl_params.get("nu")  # model.u.size()[0]
         self.ny = self.nx + self.nu
 
-        self.Nsim= int(self.srefs[-1] * self.N / (self.v * self.Tf))
-        self.ds = self.v*self.Tf/self.N
+        self.Nsim = int(self.srefs[-1] * self.N / (self.velocity_setpoint * self.Tf))
+        self.ds = self.velocity_setpoint * self.Tf / self.N
 
-    def get_commands(self,pose_x,pose_y,pose_psi,v):
+    def get_commands(self, pose_x, pose_y, pose_psi, v):
         self.pose_x = pose_x
         self.pose_y = pose_y
         self.pose_psi = pose_psi
-        #Get Nearest Reference Point
-        x0 = np.array([self.pose_x,self.pose_y,0,0,0,self.pose_psi,0])
+        # Get Nearest Reference Point
+        x0 = np.array([self.pose_x, self.pose_y, 0, 0, 0, self.pose_psi, 0])
         self.acados_solver.set(0, "lbx", x0)
         self.acados_solver.set(0, "ubx", x0)
-        normArray = np.sqrt((self.xrefs - x0[0])**2 + (self.yrefs - x0[1])**2)
+        normArray = np.sqrt((self.xrefs - x0[0]) ** 2 + (self.yrefs - x0[1]) ** 2)
         start_ref = np.argmin(normArray)
         current_sref = self.srefs[start_ref]
 
-        #Set OCP References
+        # Set OCP References
         for j in range(self.N):
             try:
-                relative_s_dist = current_sref - self.srefs 
+                relative_s_dist = current_sref - self.srefs
                 refs0_idx = len(relative_s_dist[relative_s_dist > 0])
-                sratio = ((current_sref - self.srefs[refs0_idx])/(self.srefs[refs0_idx+1]-self.srefs[refs0_idx]))
-                xrefs_interpolated = sratio*(self.xrefs[refs0_idx+1]-self.xrefs[refs0_idx])+self.xrefs[refs0_idx]
-                yrefs_interpolated = sratio*(self.yrefs[refs0_idx+1]-self.yrefs[refs0_idx])+self.yrefs[refs0_idx]
+                sratio = (current_sref - self.srefs[refs0_idx]) / (
+                    self.srefs[refs0_idx + 1] - self.srefs[refs0_idx]
+                )
+                xrefs_interpolated = (
+                    sratio * (self.xrefs[refs0_idx + 1] - self.xrefs[refs0_idx])
+                    + self.xrefs[refs0_idx]
+                )
+                yrefs_interpolated = (
+                    sratio * (self.yrefs[refs0_idx + 1] - self.yrefs[refs0_idx])
+                    + self.yrefs[refs0_idx]
+                )
                 psirefs_interpolated = self.psirefs[refs0_idx]
-                yref = np.array([xrefs_interpolated, yrefs_interpolated, 0, 0, 0, psirefs_interpolated, 0, 0])
+                yref = np.array(
+                    [
+                        xrefs_interpolated,
+                        yrefs_interpolated,
+                        0,
+                        0,
+                        0,
+                        psirefs_interpolated,
+                        0,
+                        0,
+                    ]
+                )
             except IndexError:
-                yref = np.array([self.xrefs[-1], self.yrefs[-1], 0, 0, 0, self.psirefs[-1], 0, 0])
+                yref = np.array(
+                    [self.xrefs[-1], self.yrefs[-1], 0, 0, 0, self.psirefs[-1], 0, 0]
+                )
 
             self.acados_solver.set(j, "yref", yref)
             current_sref += self.ds
-        try:        
+        try:
             yref_N = yref[:-1]
         except IndexError:
-            yref_N = np.array([self.xrefs[-1], self.yrefs[-1], 0, 0, 0, self.psirefs[-1], 0])
+            yref_N = np.array(
+                [self.xrefs[-1], self.yrefs[-1], 0, 0, 0, self.psirefs[-1], 0]
+            )
         self.acados_solver.set(self.N, "yref", yref_N)
 
-        #Solve the OCP Problem and Fetch First Input
+        # Solve the OCP Problem and Fetch First Input
         status = self.acados_solver.solve()
         if status != 0:
             self.acados_solver.reset()
 
         steering_angle = float(self.acados_solver.get(0, "u"))
 
-        speed_cmd = self.v
+        waypoints = np.hstack(
+            (
+                self.waypoints.x[np.newaxis].T,
+                self.waypoints.y[np.newaxis].T,
+                self.waypoints.psi[np.newaxis].T,
+            )
+        )
+        pose = np.array([[pose_x, pose_y]])
+        _, closest_i = get_closest_waypoint(pose, waypoints)
+        # Ramp up or down velocity based on distance traveled.
+        d = self.waypoints.d[closest_i]
+        speed_cmd = get_speed_cmd(
+            d, self.d_accel, self.d_decel, self.max_accel, self.velocity_setpoint
+        )
 
         return steering_angle, speed_cmd, self.xrefs[start_ref], self.yrefs[start_ref]

--- a/src/ros2_car_control/ros2_car_control/utilities.py
+++ b/src/ros2_car_control/ros2_car_control/utilities.py
@@ -42,3 +42,20 @@ def get_lateral_errors(
     crosstrack_err = ref_to_axle.dot(crosstrack_vector)
     yaw_err = pose[0, 2] - reference_pose[0, 2]
     return crosstrack_err, -yaw_err
+
+
+def get_accel_dist(max_velocity, max_accel):
+    """Get the distance at which the max velocity is reached with constant max accel."""
+    return max_velocity**2 / 2 / max_accel
+
+
+def get_speed_cmd(dist, dist_accel, dist_decel, max_accel, max_velocity):
+    """Get the speed command assuming a constant acceleration period until the max
+    velocity is reached and a constant deceleration until at rest."""
+    if dist > dist_accel and dist < dist_decel:
+        speed_cmd = max_velocity
+    elif dist < dist_accel:
+        speed_cmd = np.sqrt(2 * max_accel * dist)
+    elif dist > dist_decel:
+        speed_cmd = np.sqrt(max_velocity**2 - 2 * max_accel * (dist - dist_decel))
+    return np.clip(speed_cmd, 0, max_velocity)

--- a/src/ros2_car_control/ros2_car_control/utilities.py
+++ b/src/ros2_car_control/ros2_car_control/utilities.py
@@ -55,7 +55,12 @@ def get_speed_cmd(dist, dist_accel, dist_decel, max_accel, max_velocity):
     if dist > dist_accel and dist < dist_decel:
         speed_cmd = max_velocity
     elif dist < dist_accel:
-        speed_cmd = np.sqrt(2 * max_accel * dist)
-    elif dist > dist_decel:
-        speed_cmd = np.sqrt(max_velocity**2 - 2 * max_accel * (dist - dist_decel))
+        # Offset the beginning of the ramp to get the vehicle to move at start.
+        speed_cmd = np.sqrt(2 * max_accel * dist) + 0.1
+    # Inflate distance so that deceleration ends with 0 earlier.
+    elif dist + 0.2 > dist_decel:
+        speed_cmd_sqrd = max_velocity**2 - 2 * max_accel * (dist + 0.2 - dist_decel)
+        # Prevent sqrt of a negative.
+        speed_cmd_sqrd = max(speed_cmd_sqrd, 0)
+        speed_cmd = np.sqrt(speed_cmd_sqrd)
     return np.clip(speed_cmd, 0, max_velocity)

--- a/src/ros2_car_control/ros2_car_control/waypoints_pub.py
+++ b/src/ros2_car_control/ros2_car_control/waypoints_pub.py
@@ -5,6 +5,7 @@ from ros2_car_control.fetchWaypoints import waypoints
 from visualization_msgs.msg import Marker, MarkerArray
 from rclpy.duration import Duration
 from tf_transformations import quaternion_from_euler
+import sys
 
 
 class WaypointPublisher(Node):
@@ -57,10 +58,10 @@ def main(args=None):
     except SystemExit:
         pass
     except ExternalShutdownException:
-        pass
-
-    waypoint_publisher.destroy_node()
-    rclpy.shutdown()
+        sys.exit(1)
+    finally:
+        waypoint_publisher.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/src/ros2_car_control/ros2_car_control/waypoints_pub.py
+++ b/src/ros2_car_control/ros2_car_control/waypoints_pub.py
@@ -1,4 +1,5 @@
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from ros2_car_control.fetchWaypoints import waypoints
 from visualization_msgs.msg import Marker, MarkerArray
@@ -49,7 +50,14 @@ def main(args=None):
 
     waypoint_publisher = WaypointPublisher()
 
-    rclpy.spin(waypoint_publisher)
+    try:
+        rclpy.spin(waypoint_publisher)
+    except KeyboardInterrupt:
+        pass
+    except SystemExit:
+        pass
+    except ExternalShutdownException:
+        pass
 
     waypoint_publisher.destroy_node()
     rclpy.shutdown()

--- a/src/ros2_traxxas_controls/config/motor_driver.yaml
+++ b/src/ros2_traxxas_controls/config/motor_driver.yaml
@@ -8,3 +8,4 @@ motor_driver:
     throttle_register_revr: 3276
     max_steer_angle: 0.65 # radians
     max_accel: 5.0 #m/s^2
+    crash_accel: 10.0 # m/s^2

--- a/src/ros2_traxxas_controls/ros2_traxxas_controls/ros2_traxxas_motor_commands.py
+++ b/src/ros2_traxxas_controls/ros2_traxxas_controls/ros2_traxxas_motor_commands.py
@@ -26,7 +26,7 @@ class MotorCommands(Node):
             Odometry, "rear_wss", self.odom_callback, FMLCarQoS
         )
         self.accel_subscription = self.create_subscription(
-            Imu, "imu", self.accel_callback, FMLCarQoS
+            Imu, "imu/data", self.accel_callback, FMLCarQoS
         )
         self.command_subscription  # prevents unused variable warning
         self.speed_subscription


### PR DESCRIPTION
Motor Controller Changes:
- added `crash_accel` configuration parameter to motor driver
- added crash detection via x accel greater than 10 m/s^2
- renamed function names to be more meaningful
- fixed motor controller imu topic name
- lowered max throttle value from `40` to `20` (it was too aggressive)
- remove timeout required for max throttle value. (vehicle would spin up after crashing, it should shut off immediately)

Lateral Controller Changes:
- added functions to `utilities.py` so that the controller can ramp up to the set velocity and ramp down to full stop.
- added distance attribute to waypoints so that the ramp up and ramp down are scheduled with distance along the maneuver
- fixed steering saturation warning message bug where it would print when not needed
- separated safety checks so that the error messages are more specific.
- Fixed controller node's exit process so that it exits cleanly.
- Fixed waypoint publisher's exit process so that it exits cleanly.
- Reformatted all the code in `ros2_car_control/ros2_car_control`
